### PR TITLE
fix curl 7.66 bug

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,5 +5,6 @@ RUN apk --no-cache add \
           zip groff less python py-pip jq python-dev libc-dev gcc \
           libffi-dev openssl-dev make abuild binutils \
           nodejs-current nodejs-current-npm rsync \
+     && apk add --no-cache --upgrade curl \
      && pip --no-cache-dir install docker-compose awscli aws-sam-cli \
      && rm -rf /var/cache/apk/*


### PR DESCRIPTION
> Error relocating /usr/bin/curl: curl_multi_poll: symbol not found

Issue discussed: https://github.com/curl/curl/issues/4357